### PR TITLE
Add notification for current state of Meteor 3 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 > - [Blaze](https://github.com/meteor/meteor3-blaze/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/blaze/))
 > - [Svelte](https://github.com/meteor/meteor3-svelte/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/svelte/))
 
+> New to Meteor? Check out the [official documentation](https://docs.meteor.com/) and the [installation guide](https://docs.meteor.com/about/install.html) to get started.
+
 ---
 
 ### Ready
@@ -166,3 +168,11 @@
 We want to list only up-to-date examples here.
 
 If you see old examples that are no longer representing the current state of Meteor or that are not working please open a PR removing it from here.
+
+## Join the Meteor Renaissance!
+
+We're excited about what's to come and can't wait for you to join the Meteor renaissance!
+
+For feedback, questions, or support, visit our [forums](https://forums.meteor.com/) or join our [Discord channel](https://discord.com/invite/3w7EKdpghq).
+
+Follow us on [Twitter](https://x.com/meteorjs) and [GitHub](https://github.com/meteor).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
 ## Examples of Meteor Projects
 
+> **Note: We are currently modernizing all the apps in this repository to support the latest Meteor 3.4.**
+>
+> In the meantime, here are some up-to-date resources you can check out:
+>
+> **Skeletons**: Quickly scaffold a new Meteor app using `meteor create` with any of the available skeletons:
+>
+> `--bare`, `--minimal`, `--full`, `--react` (default), `--vue`, `--apollo`, `--svelte`, `--blaze`, `--tailwind`, `--chakra-ui`, `--solid`, `--angular`, `--typescript`, `--babel`, `--coffeescript`, `--prototype`
+>
+> Run [`meteor create --help`](https://docs.meteor.com/cli/#meteorcreate) to see all options.
+>
+> **Example Apps:**
+> - [Simple Tasks](https://github.com/fredmaiaarantes/simpletasks): A task management app with Meteor Accounts, Chakra UI, Formik, and MongoDB
+> - [Welcome Meteor Cordova](https://github.com/CloudByGalaxy/welcome-meteor-cordova): For Cordova / mobile usage
+>
+> **Tutorial Apps (Meteor 3.4 + Rspack):**
+> - [React](https://github.com/meteor/meteor3-react/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/react/))
+> - [Solid](https://github.com/meteor/meteor3-solid/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/solid/))
+> - [Vue 3](https://github.com/meteor/meteor3-vue3/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/vue/meteorjs3-vue3.html))
+> - [Blaze](https://github.com/meteor/meteor3-blaze/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/blaze/))
+> - [Svelte](https://github.com/meteor/meteor3-svelte/tree/3.4-rspack) ([tutorial](https://docs.meteor.com/tutorials/svelte/))
+
+---
+
 ### Ready
+
+#### Simple Tasks
+
+- Demo: [simpletasks2.meteorapp.com/](https://simpletasks2.meteorapp.com)
+- Repository: [fredmaiaarantes/simpletasks](https://github.com/fredmaiaarantes/simpletasks)
+- Why: To show how to use Meteor with [Chakra UI](https://chakra-ui.com/) + [Formik](https://formik.org/) + MongoDB
+- Stack: Meteor, Rspack, Chakra UI, React, Formik, MongoDB
+- Last Updated At: Feb/12/2026
+- Meteor Version: 3.4
+
+### To migrate - WIP
 
 #### Tic tac toe
 - Demo: [tic-tac-toe.meteorapp.com](https://tic-tac-toe.meteorapp.com)
@@ -9,14 +43,6 @@
 - Stack: Meteor and React
 - Last Updated At: Sep/06/2022
 - Meteor Version: 2.7.3
-
-#### Simple Tasks
-- Demo: [simpletasks.meteorapp.com/](https://simpletasks.meteorapp.com)
-- Repository: [fredmaiaarantes/simpletasks](https://github.com/fredmaiaarantes/simpletasks)
-- Why: To show how to use Meteor with [Chakra UI](https://chakra-ui.com/) + [Formik](https://formik.org/) + MongoDB
-- Stack: Meteor, Chakra UI, React, Formik, MongoDB
-- Last Updated At: Apr/07/2021
-- Meteor Version: 2.1.1
 
 #### Complex Svelte Todos
 - Demo: [complex-todos-svelte.meteorapp.com/](https://complex-todos-svelte.meteorapp.com)
@@ -40,22 +66,6 @@
 - Stack: Tailwindcss, Meteor and React
 - Last Updated At: Nov/10/2022
 - Meteor Version: 2.8
-
-#### Wantch: Manage Movies to Watch
-- Demo: [wantch.meteorapp.com](https://wantch.meteorapp.com)
-- Repository: [filipenevola/wantch](https://github.com/filipenevola/wantch)
-- Why: To show how simple is to create an app using Meteor Methods and React
-- Stack: Meteor, React and PWA
-- Last Updated At: Feb/25/2021
-- Meteor Version: 2.1
-
-#### Double app
-- Demo: [double-app.meteorapp.com](https://double-app.meteorapp.com)
-- Repository: [denihs/double-app](https://github.com/denihs/double-app/)
-- Why: To show how to have two apps with different purposes, but sharing the same codebase. 
-- Stack: Meteor and React
-- Last Updated At: Mar/19/2021
-- Meteor Version: 2.1
 
 ### Leaderboards
 - Demo: N/A
@@ -96,23 +106,6 @@
 - Stack: Meteor and Blaze
 - Last Updated At: May/19/2025
 - Meteor Version: 3.2.2
-
-### WIP
-#### Parties
-- Demo: N/A
-- Repository: [meteor/examples/parties](./parties)
-- Why: One of the original Meteor examples showcasing how to build a nice working application with Blaze with very little code, while taking advantage of optimistic updates.
-- Stack: Meteor, Blaze
-- Last Updated At: August/23/2021
-- Meteor Version: 2.3.5
-
-#### Native app with Cordova
-- Demo: N/A
-- Repository: [meteor/examples/cordova](./cordova)
-- Why: To show how to set up a proper Native app with Meteor and Cordova
-- Stack: Meteor and Cordova
-- Last Updated At: May/22/2020
-- Meteor Version: 1.10.3
 
 ## How to add your example?
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@
 ## How to add your example?
 
 - Create a PR including it in this README
-- Make sure you are using the latest Meteor
+- Make sure you are using the latest Meteor (Meteor 3.x)
 - Required fields: Repository, Why, Stack, Last Updated At and Meteor Version.
 
 ## Housekeeping

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@
 - Last Updated At: May/19/2025
 - Meteor Version: 3.2.2
 
+### Parties
+- Demo: N/A
+- Repository: [meteor/examples/parties](./parties)
+- Why: One of the original Meteor examples showcasing how to build a nice working application with Blaze with very little code, while taking advantage of optimistic updates.
+- Stack: Meteor, Blaze
+- Last Updated At: August/23/2021
+- Meteor Version: 2.3.5
+
 ## How to add your example?
 
 - Create a PR including it in this README

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ If you see old examples that are no longer representing the current state of Met
 
 ## Join the Meteor Renaissance!
 
+Meteor 3 starts a new era for building web applications, with multiplatform support, realtime features, modern JavaScript patterns, and a simple starting point. It gives you the flexibility of Node.js together with built-in tools and ready-to-use packages, so you can stay focused on the product.
+
 We're excited about what's to come and can't wait for you to join the Meteor renaissance!
 
 For feedback, questions, or support, visit our [forums](https://forums.meteor.com/) or join our [Discord channel](https://discord.com/invite/3w7EKdpghq).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,53 @@
 - Last Updated At: Feb/12/2026
 - Meteor Version: 3.4
 
+#### Welcome Meteor Cordova
+- Demo: N/A
+- Repository: [CloudByGalaxy/welcome-meteor-cordova](https://github.com/CloudByGalaxy/welcome-meteor-cordova)
+- Why: To show how to set up a Meteor app with Cordova for mobile usage
+- Stack: Meteor, Cordova
+- Meteor Version: 3.4
+
+#### React Tutorial App
+- Demo: N/A
+- Tutorial: [docs.meteor.com/tutorials/react](https://docs.meteor.com/tutorials/react/)
+- Repository: [meteor/meteor3-react (3.4-rspack)](https://github.com/meteor/meteor3-react/tree/3.4-rspack)
+- Why: To show how to build a Meteor app with React following the official tutorial
+- Stack: Meteor, Rspack, React
+- Meteor Version: 3.4
+
+#### Solid Tutorial App
+- Demo: N/A
+- Tutorial: [docs.meteor.com/tutorials/solid](https://docs.meteor.com/tutorials/solid/)
+- Repository: [meteor/meteor3-solid (3.4-rspack)](https://github.com/meteor/meteor3-solid/tree/3.4-rspack)
+- Why: To show how to build a Meteor app with Solid following the official tutorial
+- Stack: Meteor, Rspack, Solid
+- Meteor Version: 3.4
+
+#### Vue 3 Tutorial App
+- Demo: N/A
+- Tutorial: [docs.meteor.com/tutorials/vue](https://docs.meteor.com/tutorials/vue/meteorjs3-vue3.html)
+- Repository: [meteor/meteor3-vue3 (3.4-rspack)](https://github.com/meteor/meteor3-vue3/tree/3.4-rspack)
+- Why: To show how to build a Meteor app with Vue 3 following the official tutorial
+- Stack: Meteor, Rspack, Vue 3
+- Meteor Version: 3.4
+
+#### Blaze Tutorial App
+- Demo: N/A
+- Tutorial: [docs.meteor.com/tutorials/blaze](https://docs.meteor.com/tutorials/blaze/)
+- Repository: [meteor/meteor3-blaze (3.4-rspack)](https://github.com/meteor/meteor3-blaze/tree/3.4-rspack)
+- Why: To show how to build a Meteor app with Blaze following the official tutorial
+- Stack: Meteor, Rspack, Blaze
+- Meteor Version: 3.4
+
+#### Svelte Tutorial App
+- Demo: N/A
+- Tutorial: [docs.meteor.com/tutorials/svelte](https://docs.meteor.com/tutorials/svelte/)
+- Repository: [meteor/meteor3-svelte (3.4-rspack)](https://github.com/meteor/meteor3-svelte/tree/3.4-rspack)
+- Why: To show how to build a Meteor app with Svelte following the official tutorial
+- Stack: Meteor, Rspack, Svelte
+- Meteor Version: 3.4
+
 ### To migrate - WIP
 
 #### Tic tac toe

--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@
 - Last Updated At: Sep/06/2022
 - Meteor Version: 2.7.3
 
-#### Complex Svelte Todos
-- Demo: [complex-todos-svelte.meteorapp.com/](https://complex-todos-svelte.meteorapp.com)
-- Repository: [guncebektas/complex-todos-svelte](https://github.com/guncebektas/complex-todos-svelte)
-- Why: To show how to use Meteor in real world problems.
-- Stack: Meteor, Svelte, Bootstrap, MongoDB, Cypress
-- Last Updated At: Aug/21/2021
-
 #### Chakra UI
 - Demo: [chakraui.meteorapp.com](https://chakraui.meteorapp.com/)
 - Repository: [meteor/examples/chakra-ui](./chakra-ui)


### PR DESCRIPTION
This PR reviews the list of provided examples to ensure it shows only those that:

* Have been properly adapted to the latest Meteor 3.4
* Are inside the meteor/* project and will be migrated next

As the README states, [it is our responsibility to keep this list up to date](https://github.com/meteor/examples#housekeeping), and any app that is not available for the latest Meteor version will no longer be shown.

If you have a new or existing example migrated and ready for Meteor 3.x, don't hesitate to open a PR to include it.